### PR TITLE
Fix indentation in compose.yml

### DIFF
--- a/src/main/resources/archetype-resources/docker-compose.yml
+++ b/src/main/resources/archetype-resources/docker-compose.yml
@@ -17,7 +17,7 @@
 version: "2"
 services:
   zookeeper:
-      image: confluentinc/cp-zookeeper:5.4.0
+    image: confluentinc/cp-zookeeper:5.4.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       zk_id: "1"


### PR DESCRIPTION
docker-compose fails due to broken indentation - more broadly I'm wondering if this should include a connect cluster?